### PR TITLE
Add jetpack support(androidx) to [master]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,10 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 
 android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     compileSdkVersion rootProject.compileSdkVersion
     defaultConfig {
         applicationId "com.example.android.codelabs.paging"
@@ -39,18 +43,17 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    implementation "com.android.support:appcompat-v7:$supportLibVersion"
-    implementation "com.android.support.constraint:constraint-layout:$constraintLayoutVersion"
-    implementation "com.android.support:design:$supportLibVersion"
+    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "androidx.appcompat:appcompat:$appCompat"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
+    implementation "com.google.android.material:material:$design"
 
     // architecture components
-    implementation "android.arch.lifecycle:extensions:$archComponentsVersion"
-    implementation "android.arch.lifecycle:runtime:$archComponentsVersion"
-    implementation "android.arch.persistence.room:runtime:$roomVersion"
-    implementation "android.arch.paging:runtime:$pagingVersion"
-    kapt "android.arch.lifecycle:compiler:$archComponentsVersion"
-    kapt "android.arch.persistence.room:compiler:$roomVersion"
+    implementation "androidx.paging:paging-runtime:$pagingVersion"
+    kapt "androidx.room:room-compiler:$roomVersion"
+    implementation "androidx.room:room-runtime:$roomVersion"
+    implementation "androidx.lifecycle:lifecycle-extensions:$archComponentsVersion"
+    implementation "androidx.lifecycle:lifecycle-common-java8:$archComponentsVersion"
 
     // retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
@@ -60,6 +63,6 @@ dependencies {
 
     // testing
     testImplementation "junit:junit:$junitVersion"
-    androidTestImplementation "com.android.support.test:runner:$runnerVersion"
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
+    androidTestImplementation "androidx.test:runner:$runnerVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 }

--- a/app/src/main/java/com/example/android/codelabs/paging/Injection.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/Injection.kt
@@ -16,8 +16,8 @@
 
 package com.example.android.codelabs.paging
 
-import android.arch.lifecycle.ViewModelProvider
 import android.content.Context
+import androidx.lifecycle.ViewModelProvider
 import com.example.android.codelabs.paging.api.GithubService
 import com.example.android.codelabs.paging.data.GithubRepository
 import com.example.android.codelabs.paging.db.GithubLocalCache

--- a/app/src/main/java/com/example/android/codelabs/paging/data/GithubRepository.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/data/GithubRepository.kt
@@ -16,8 +16,8 @@
 
 package com.example.android.codelabs.paging.data
 
-import android.arch.lifecycle.MutableLiveData
 import android.util.Log
+import androidx.lifecycle.MutableLiveData
 import com.example.android.codelabs.paging.api.GithubService
 import com.example.android.codelabs.paging.api.searchRepos
 import com.example.android.codelabs.paging.db.GithubLocalCache

--- a/app/src/main/java/com/example/android/codelabs/paging/db/GithubLocalCache.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/db/GithubLocalCache.kt
@@ -16,9 +16,8 @@
 
 package com.example.android.codelabs.paging.db
 
-import android.arch.lifecycle.LiveData
-import android.arch.paging.DataSource
 import android.util.Log
+import androidx.lifecycle.LiveData
 import com.example.android.codelabs.paging.model.Repo
 import java.util.concurrent.Executor
 

--- a/app/src/main/java/com/example/android/codelabs/paging/db/RepoDao.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/db/RepoDao.kt
@@ -16,11 +16,11 @@
 
 package com.example.android.codelabs.paging.db
 
-import android.arch.lifecycle.LiveData
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.OnConflictStrategy
-import android.arch.persistence.room.Query
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import com.example.android.codelabs.paging.model.Repo
 
 /**

--- a/app/src/main/java/com/example/android/codelabs/paging/db/RepoDatabase.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/db/RepoDatabase.kt
@@ -16,10 +16,10 @@
 
 package com.example.android.codelabs.paging.db
 
-import android.arch.persistence.room.Database
-import android.arch.persistence.room.Room
-import android.arch.persistence.room.RoomDatabase
 import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
 import com.example.android.codelabs.paging.model.Repo
 
 /**

--- a/app/src/main/java/com/example/android/codelabs/paging/model/Repo.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/model/Repo.kt
@@ -16,8 +16,8 @@
 
 package com.example.android.codelabs.paging.model
 
-import android.arch.persistence.room.Entity
-import android.arch.persistence.room.PrimaryKey
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
 
 /**

--- a/app/src/main/java/com/example/android/codelabs/paging/model/RepoSearchResult.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/model/RepoSearchResult.kt
@@ -16,7 +16,7 @@
 
 package com.example.android.codelabs.paging.model
 
-import android.arch.lifecycle.LiveData
+import androidx.lifecycle.LiveData
 
 /**
  * RepoSearchResult from a search, which contains LiveData<List<Repo>> holding query data,

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/RepoViewHolder.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/RepoViewHolder.kt
@@ -18,11 +18,11 @@ package com.example.android.codelabs.paging.ui
 
 import android.content.Intent
 import android.net.Uri
-import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
 import com.example.android.codelabs.paging.R
 import com.example.android.codelabs.paging.model.Repo
 

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/ReposAdapter.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/ReposAdapter.kt
@@ -16,10 +16,10 @@
 
 package com.example.android.codelabs.paging.ui
 
-import android.support.v7.recyclerview.extensions.ListAdapter
-import android.support.v7.util.DiffUtil
-import android.support.v7.widget.RecyclerView
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import com.example.android.codelabs.paging.model.Repo
 
 /**

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesActivity.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesActivity.kt
@@ -16,23 +16,24 @@
 
 package com.example.android.codelabs.paging.ui
 
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.DividerItemDecoration
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
 import android.util.Log
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.Toast
-import com.example.android.codelabs.paging.R
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.example.android.codelabs.paging.Injection
+import com.example.android.codelabs.paging.R
 import com.example.android.codelabs.paging.model.Repo
-import kotlinx.android.synthetic.main.activity_search_repositories.*
-
+import kotlinx.android.synthetic.main.activity_search_repositories.emptyList
+import kotlinx.android.synthetic.main.activity_search_repositories.list
+import kotlinx.android.synthetic.main.activity_search_repositories.search_repo
 
 class SearchRepositoriesActivity : AppCompatActivity() {
 
@@ -119,7 +120,7 @@ class SearchRepositoriesActivity : AppCompatActivity() {
     private fun setupScrollListener() {
         val layoutManager = list.layoutManager as LinearLayoutManager
         list.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-            override fun onScrolled(recyclerView: RecyclerView?, dx: Int, dy: Int) {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
                 val totalItemCount = layoutManager.itemCount
                 val visibleItemCount = layoutManager.childCount

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesViewModel.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesViewModel.kt
@@ -16,10 +16,10 @@
 
 package com.example.android.codelabs.paging.ui
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
-import android.arch.lifecycle.Transformations
-import android.arch.lifecycle.ViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Transformations
+import androidx.lifecycle.ViewModel
 import com.example.android.codelabs.paging.data.GithubRepository
 import com.example.android.codelabs.paging.model.Repo
 import com.example.android.codelabs.paging.model.RepoSearchResult

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/ViewModelFactory.kt
@@ -16,8 +16,8 @@
 
 package com.example.android.codelabs.paging.ui
 
-import android.arch.lifecycle.ViewModel
-import android.arch.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.example.android.codelabs.paging.data.GithubRepository
 
 /**

--- a/app/src/main/res/layout/activity_search_repositories.xml
+++ b/app/src/main/res/layout/activity_search_repositories.xml
@@ -15,14 +15,14 @@
   ~ limitations under the License.
   -->
 
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.SearchRepositoriesActivity">
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -42,15 +42,15 @@
             android:imeOptions="actionSearch"
             android:inputType="textNoSuggestions"
             tools:text="Android"/>
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/list"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:paddingVertical="@dimen/row_item_margin_vertical"
         android:scrollbars="vertical"
-        app:layoutManager="LinearLayoutManager"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -69,4 +69,4 @@
               app:layout_constraintStart_toStartOf="parent"
               app:layout_constraintTop_toTopOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/repo_view_item.xml
+++ b/app/src/main/res/layout/repo_view_item.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -103,4 +103,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/repo_description"
         tools:text="30"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha04'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha05'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha06'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.2.51'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha09'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -43,19 +43,21 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 27
+    compileSdkVersion = 28
     minSdkVersion = 15
-    targetSdkVersion = 27
-    supportLibVersion = "27.1.0"
-    constraintLayoutVersion = "1.0.2"
-    archComponentsVersion = "1.1.1"
-    roomVersion = "1.1.0-beta1"
-    pagingVersion = "1.0.0-beta1"
+    targetSdkVersion = 28
+    appCompat = "1.0.0-beta01"
+    constraintLayoutVersion = "1.1.2"
+    design = "1.0.0-beta01"
+    pagingVersion = "2.0.0-beta01"
+    roomVersion = "2.0.0-beta01"
+    archComponentsVersion = "2.0.0-beta01"
+
+    runnerVersion = "1.1.0-alpha1"
+    espressoVersion = "3.1.0-alpha1"
+
+    junitVersion = "4.12"
+
     retrofitVersion = "2.3.0"
     okhttpLoggingInterceptorVersion = "3.9.0"
-
-    runnerVersion = "1.0.1"
-    rulesVersion = "1.0.1"
-    junitVersion = "4.12"
-    espressoVersion = "3.0.1"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.60'
+    ext.kotlin_version = '1.2.61'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha06'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha08'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.51'
+    ext.kotlin_version = '1.2.60'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha03'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,6 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 04 14:02:03 BST 2018
+#Mon Jul 16 11:21:28 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-rc-1-all.zip


### PR DESCRIPTION
For the future, it's better to update this classical demo to androidx as earlier as possible.

1. Turn on jetpack
2. Update kt-files, layout-xmls
3. Gradle(also build.gradle files) and Kotlin plugins upgrade