### PR TITLE
Fix RemoteMediator implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://androidx-dev-prod.appspot.com/snapshots/builds/6396248/artifacts/repository' }
+        maven { url 'https://androidx-dev-prod.appspot.com/snapshots/builds/6397162/artifacts/repository' }
     }
 }
 


### PR DESCRIPTION
Will need to wait for this fix to land: https://android-review.googlesource.com/c/platform/frameworks/support/+/1285582

Btw: withTransaction already dispatches on the room threadpool, so no need for Dispatchers.IO

I might have incorrectly given you this check last time: `state.pages.lastOrNull { it.data.isNotEmpty() }`, as it filters out the last page which has the nextKey correctly set to null. This was causing an infinite-loop of using the second last page's next key to invalidate and load the empty last page over and over again