### PR TITLE
RemoteMediator fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,8 @@ dependencies {
     implementation "com.google.android.material:material:$materialVersion"
 
     // architecture components
+    implementation "androidx.core:core-ktx:$coreVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/ReposLoadStateViewHolder.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/ReposLoadStateViewHolder.kt
@@ -19,6 +19,7 @@ package com.example.android.codelabs.paging.ui
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.RecyclerView
 import com.example.android.codelabs.paging.R
@@ -37,9 +38,9 @@ class ReposLoadStateViewHolder(
         if (loadState is LoadState.Error) {
             binding.errorMsg.text = loadState.error.localizedMessage
         }
-        binding.progressBar.visibility = toVisibility(loadState is LoadState.Loading)
-        binding.retryButton.visibility = toVisibility(loadState !is LoadState.Loading)
-        binding.errorMsg.visibility = toVisibility(loadState !is LoadState.Loading)
+        binding.progressBar.isVisible = loadState is LoadState.Loading
+        binding.retryButton.isVisible = loadState !is LoadState.Loading
+        binding.errorMsg.isVisible = loadState !is LoadState.Loading
     }
 
     companion object {

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesActivity.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesActivity.kt
@@ -18,10 +18,10 @@ package com.example.android.codelabs.paging.ui
 
 import android.os.Bundle
 import android.view.KeyEvent
-import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.ExperimentalPagingApi
@@ -60,7 +60,7 @@ class SearchRepositoriesActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
-// get the view model
+        // get the view model
         viewModel = ViewModelProvider(this, Injection.provideViewModelFactory(this))
                 .get(SearchRepositoriesViewModel::class.java)
 
@@ -85,41 +85,28 @@ class SearchRepositoriesActivity : AppCompatActivity() {
                 header = ReposLoadStateAdapter { adapter.retry() },
                 footer = ReposLoadStateAdapter { adapter.retry() }
         )
+
         adapter.addLoadStateListener { loadState ->
-            if (loadState.refresh !is LoadState.NotLoading) {
-                // We're refreshing: either loading or we had an error
-                // So we can hide the list
-                binding.list.visibility = View.GONE
-                binding.progressBar.visibility = toVisibility(loadState.refresh is LoadState.Loading)
-                binding.retryButton.visibility = toVisibility(loadState.refresh is LoadState.Error)
-            } else {
-                // We're not refreshing - we're either prepending or appending
-                // So we should show the list
-                binding.list.visibility = View.VISIBLE
-                binding.progressBar.visibility = View.GONE
-                binding.retryButton.visibility = View.GONE
-                // If we have an error, show a toast
-                val errorState = when {
-                    loadState.append is LoadState.Error -> {
-                        loadState.append as LoadState.Error
-                    }
-                    loadState.prepend is LoadState.Error -> {
-                        loadState.prepend as LoadState.Error
-                    }
-                    else -> {
-                        null
-                    }
-                }
-                errorState?.let {
-                    Toast.makeText(
-                            this,
-                            "\uD83D\uDE28 Wooops ${it.error}",
-                            Toast.LENGTH_LONG
-                    ).show()
-                }
+            // Only show the list if refresh succeeds.
+            binding.list.isVisible = loadState.refresh is LoadState.NotLoading
+            // Show loading spinner during initial load or refresh.
+            binding.progressBar.isVisible = loadState.refresh is LoadState.Loading
+            // Show the retry state if initial load or refresh fails.
+            binding.retryButton.isVisible = loadState.refresh is LoadState.Error
+
+            // Toast on any error, regardless of whether it came from RemoteMediator or PagingSource
+            val errorState = loadState.source.append as? LoadState.Error
+                    ?: loadState.source.prepend as? LoadState.Error
+                    ?: loadState.append as? LoadState.Error
+                    ?: loadState.prepend as? LoadState.Error
+            errorState?.let {
+                Toast.makeText(
+                        this,
+                        "\uD83D\uDE28 Wooops ${it.error}",
+                        Toast.LENGTH_LONG
+                ).show()
             }
         }
-
     }
 
     private fun initSearch(query: String) {

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/UiUtils.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/UiUtils.kt
@@ -1,9 +1,0 @@
-package com.example.android.codelabs.paging.ui
-
-import android.view.View
-
-fun toVisibility(constraint: Boolean): Int = if (constraint) {
-    View.VISIBLE
-} else {
-    View.GONE
-}

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ ext {
     minSdkVersion = 15
     targetSdkVersion = 28
     supportLibVersion = '1.1.0'
+    coreVersion = '1.3.0'
     recyclerViewVersion = '1.2.0-alpha03'
     constraintLayoutVersion = '1.1.3'
     materialVersion = '1.1.0'


### PR DESCRIPTION
Snapshot still building, so waiting for buildId.

Adding a few fixes here for a crash and to distinctUntilChanged for error toasts since we always send all load states on every update now.