### PR TITLE
Fix inital state

### DIFF
--- a/app/src/main/java/com/example/android/codelabs/paging/data/GithubPagingSource.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/data/GithubPagingSource.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.codelabs.paging.data
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.example.android.codelabs.paging.api.GithubService
+import com.example.android.codelabs.paging.api.IN_QUALIFIER
+import com.example.android.codelabs.paging.data.GithubRepository.Companion.NETWORK_PAGE_SIZE
+import com.example.android.codelabs.paging.model.Repo
+import retrofit2.HttpException
+import java.io.IOException
+
+// GitHub page API is 1 based: https://developer.github.com/v3/#pagination
+private const val GITHUB_STARTING_PAGE_INDEX = 1
+
+class GithubPagingSource(
+    private val service: GithubService,
+    private val query: String
+) : PagingSource<Int, Repo>() {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Repo> {
+        val position = params.key ?: GITHUB_STARTING_PAGE_INDEX
+        val apiQuery = query + IN_QUALIFIER
+        return try {
+            val response = service.searchRepos(apiQuery, position, params.loadSize)
+            val repos = response.items
+            val nextKey = if (repos.isEmpty()) {
+                null
+            } else {
+                // initial load size = 3 * NETWORK_PAGE_SIZE
+                // ensure we're not requesting duplicating items, at the 2nd request
+                position + (params.loadSize / NETWORK_PAGE_SIZE)
+            }
+            LoadResult.Page(
+                data = repos,
+                prevKey = if (position == GITHUB_STARTING_PAGE_INDEX) null else position - 1,
+                nextKey = nextKey
+            )
+        } catch (exception: IOException) {
+            LoadResult.Error(exception)
+        } catch (exception: HttpException) {
+            LoadResult.Error(exception)
+        }
+    }
+
+    // The refresh key is used for the initial load of the next PagingSource, after invalidation
+    override fun getRefreshKey(state: PagingState<Int, Repo>): Int? {
+        // We need to get the previous key (or next key if previous is null) of the page
+        // that was closest to the most recently accessed index.
+        // Anchor position is the most recently accessed index
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/app/src/main/java/com/example/android/codelabs/paging/data/GithubRepository.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/data/GithubRepository.kt
@@ -17,91 +17,28 @@
 package com.example.android.codelabs.paging.data
 
 import android.util.Log
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import com.example.android.codelabs.paging.api.GithubService
-import com.example.android.codelabs.paging.api.IN_QUALIFIER
 import com.example.android.codelabs.paging.model.Repo
-import com.example.android.codelabs.paging.model.RepoSearchResult
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import retrofit2.HttpException
-import java.io.IOException
-
-// GitHub page API is 1 based: https://developer.github.com/v3/#pagination
-private const val GITHUB_STARTING_PAGE_INDEX = 1
 
 /**
  * Repository class that works with local and remote data sources.
  */
 class GithubRepository(private val service: GithubService) {
 
-    // keep the list of all results received
-    private val inMemoryCache = mutableListOf<Repo>()
-
-    // shared flow of results, which allows us to broadcast updates so
-    // the subscriber will have the latest data
-    private val searchResults = MutableSharedFlow<RepoSearchResult>(replay = 1)
-
-    // keep the last requested page. When the request is successful, increment the page number.
-    private var lastRequestedPage = GITHUB_STARTING_PAGE_INDEX
-
-    // avoid triggering multiple requests in the same time
-    private var isRequestInProgress = false
-
     /**
      * Search repositories whose names match the query, exposed as a stream of data that will emit
      * every time we get more data from the network.
      */
-    suspend fun getSearchResultStream(query: String): Flow<RepoSearchResult> {
+    fun getSearchResultStream(query: String): Flow<PagingData<Repo>> {
         Log.d("GithubRepository", "New query: $query")
-        lastRequestedPage = 1
-        inMemoryCache.clear()
-        requestAndSaveData(query)
-
-        return searchResults
-    }
-
-    suspend fun requestMore(query: String) {
-        if (isRequestInProgress) return
-        val successful = requestAndSaveData(query)
-        if (successful) {
-            lastRequestedPage++
-        }
-    }
-
-    suspend fun retry(query: String) {
-        if (isRequestInProgress) return
-        requestAndSaveData(query)
-    }
-
-    private suspend fun requestAndSaveData(query: String): Boolean {
-        isRequestInProgress = true
-        var successful = false
-
-        val apiQuery = query + IN_QUALIFIER
-        try {
-            val response = service.searchRepos(apiQuery, lastRequestedPage, NETWORK_PAGE_SIZE)
-            Log.d("GithubRepository", "response $response")
-            val repos = response.items ?: emptyList()
-            inMemoryCache.addAll(repos)
-            val reposByName = reposByName(query)
-            searchResults.emit(RepoSearchResult.Success(reposByName))
-            successful = true
-        } catch (exception: IOException) {
-            searchResults.emit(RepoSearchResult.Error(exception))
-        } catch (exception: HttpException) {
-            searchResults.emit(RepoSearchResult.Error(exception))
-        }
-        isRequestInProgress = false
-        return successful
-    }
-
-    private fun reposByName(query: String): List<Repo> {
-        // from the in memory cache select only the repos whose name or description matches
-        // the query. Then order the results.
-        return inMemoryCache.filter {
-            it.name.contains(query, true) ||
-                    (it.description != null && it.description.contains(query, true))
-        }.sortedWith(compareByDescending<Repo> { it.stars }.thenBy { it.name })
+        return Pager(
+            config = PagingConfig(pageSize = NETWORK_PAGE_SIZE, enablePlaceholders = false),
+            pagingSourceFactory = { GithubPagingSource(service, query) }
+        ).flow
     }
 
     companion object {

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/ReposAdapter.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/ReposAdapter.kt
@@ -17,14 +17,14 @@
 package com.example.android.codelabs.paging.ui
 
 import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import com.example.android.codelabs.paging.model.Repo
 
 /**
  * Adapter for the list of repositories.
  */
-class ReposAdapter : ListAdapter<Repo, RepoViewHolder>(REPO_COMPARATOR) {
+class ReposAdapter : PagingDataAdapter<Repo, RepoViewHolder>(REPO_COMPARATOR) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RepoViewHolder {
         return RepoViewHolder.create(parent)

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesViewModel.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesViewModel.kt
@@ -16,19 +16,26 @@
 
 package com.example.android.codelabs.paging.ui
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
-import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.liveData
-import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import com.example.android.codelabs.paging.data.GithubRepository
-import com.example.android.codelabs.paging.model.RepoSearchResult
-import kotlinx.coroutines.Dispatchers
+import com.example.android.codelabs.paging.model.Repo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
@@ -43,7 +50,7 @@ class SearchRepositoriesViewModel(
     /**
      * Stream of immutable states representative of the UI.
      */
-    val state: LiveData<UiState>
+    val state: StateFlow<UiState>
 
     /**
      * Processor of side effects from the UI which in turn feedback into [state]
@@ -51,63 +58,81 @@ class SearchRepositoriesViewModel(
     val accept: (UiAction) -> Unit
 
     init {
-        val queryLiveData =
-            MutableLiveData(savedStateHandle.get(LAST_SEARCH_QUERY) ?: DEFAULT_QUERY)
-
-        state = queryLiveData
+        val initialQuery: String = savedStateHandle.get(LAST_SEARCH_QUERY) ?: DEFAULT_QUERY
+        val lastQueryScrolled: String? = savedStateHandle.get(LAST_QUERY_SCROLLED)
+        val actionStateFlow = MutableSharedFlow<UiAction>()
+        val searches = actionStateFlow
+            .filterIsInstance<UiAction.Search>()
             .distinctUntilChanged()
-            .switchMap { queryString ->
-                liveData {
-                    val uiState = repository.getSearchResultStream(queryString)
-                        .map {
-                            UiState(
-                                query = queryString,
-                                searchResult = it
-                            )
-                        }
-                        .asLiveData(Dispatchers.Main)
-                    emitSource(uiState)
-                }
+            .onStart { emit(UiAction.Search(query = initialQuery)) }
+        val queriesScrolled = actionStateFlow
+            .filterIsInstance<UiAction.Scroll>()
+            .distinctUntilChanged()
+            // This is shared to keep the flow "hot" while caching the last query scrolled,
+            // otherwise each flatMapLatest invocation would lose the last query scrolled,
+            .shareIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
+                replay = 1
+            )
+            .onStart { emit(UiAction.Scroll(currentQuery = lastQueryScrolled)) }
+
+        state = searches
+            .flatMapLatest { search ->
+                combine(
+                    queriesScrolled,
+                    searchRepo(queryString = search.query),
+                    ::Pair
+                )
+                    // Each unique PagingData should be submitted once, take the latest from
+                    // queriesScrolled
+                    .distinctUntilChangedBy { it.second }
+                    .map { (scroll, pagingData) ->
+                        UiState(
+                            query = search.query,
+                            pagingData = pagingData,
+                            lastQueryScrolled = scroll.currentQuery,
+                            // If the search query matches the scroll query, the user has scrolled
+                            hasNotScrolledForCurrentSearch = search.query != scroll.currentQuery
+                        )
+                    }
             }
+            .onStart { emit(UiState()) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
+                initialValue = UiState()
+            )
 
         accept = { action ->
-            when (action) {
-                is UiAction.Search -> queryLiveData.postValue(action.query)
-                is UiAction.Scroll -> if (action.shouldFetchMore) {
-                    val immutableQuery = queryLiveData.value
-                    if (immutableQuery != null) {
-                        viewModelScope.launch {
-                            repository.requestMore(immutableQuery)
-                        }
-                    }
-                }
-            }
+            viewModelScope.launch { actionStateFlow.emit(action) }
         }
     }
 
     override fun onCleared() {
-        savedStateHandle[LAST_SEARCH_QUERY] = state.value?.query
+        savedStateHandle[LAST_SEARCH_QUERY] = state.value.query
+        savedStateHandle[LAST_QUERY_SCROLLED] = state.value.lastQueryScrolled
         super.onCleared()
     }
-}
 
-private val UiAction.Scroll.shouldFetchMore
-    get() = visibleItemCount + lastVisibleItemPosition + VISIBLE_THRESHOLD >= totalItemCount
+
+    private fun searchRepo(queryString: String): Flow<PagingData<Repo>> =
+        repository.getSearchResultStream(queryString)
+            .cachedIn(viewModelScope)
+}
 
 sealed class UiAction {
     data class Search(val query: String) : UiAction()
-    data class Scroll(
-        val visibleItemCount: Int,
-        val lastVisibleItemPosition: Int,
-        val totalItemCount: Int
-    ) : UiAction()
+    data class Scroll(val currentQuery: String?) : UiAction()
 }
 
 data class UiState(
-    val query: String,
-    val searchResult: RepoSearchResult
+    val query: String = DEFAULT_QUERY,
+    val lastQueryScrolled: String? = null,
+    val hasNotScrolledForCurrentSearch: Boolean = false,
+    val pagingData: PagingData<Repo> = PagingData.empty()
 )
 
-private const val VISIBLE_THRESHOLD = 5
+private const val LAST_QUERY_SCROLLED: String = "last_query_scrolled"
 private const val LAST_SEARCH_QUERY: String = "last_search_query"
 private const val DEFAULT_QUERY = "Android"

--- a/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesViewModel.kt
+++ b/app/src/main/java/com/example/android/codelabs/paging/ui/SearchRepositoriesViewModel.kt
@@ -59,7 +59,7 @@ class SearchRepositoriesViewModel(
 
     init {
         val initialQuery: String = savedStateHandle.get(LAST_SEARCH_QUERY) ?: DEFAULT_QUERY
-        val lastQueryScrolled: String? = savedStateHandle.get(LAST_QUERY_SCROLLED)
+        val lastQueryScrolled: String = savedStateHandle.get(LAST_QUERY_SCROLLED) ?: DEFAULT_QUERY
         val actionStateFlow = MutableSharedFlow<UiAction>()
         val searches = actionStateFlow
             .filterIsInstance<UiAction.Search>()
@@ -97,7 +97,6 @@ class SearchRepositoriesViewModel(
                         )
                     }
             }
-            .onStart { emit(UiState()) }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
@@ -123,12 +122,12 @@ class SearchRepositoriesViewModel(
 
 sealed class UiAction {
     data class Search(val query: String) : UiAction()
-    data class Scroll(val currentQuery: String?) : UiAction()
+    data class Scroll(val currentQuery: String) : UiAction()
 }
 
 data class UiState(
     val query: String = DEFAULT_QUERY,
-    val lastQueryScrolled: String? = null,
+    val lastQueryScrolled: String = DEFAULT_QUERY,
     val hasNotScrolledForCurrentSearch: Boolean = false,
     val pagingData: PagingData<Repo> = PagingData.empty()
 )


### PR DESCRIPTION
@dlam fixed a small edge case with the updated codelab:

1. `lastQueryScrolled` should default to `DEFAULT_QUERY` on first launch.
2. `onStart { emit(UiState()) }` is redundant with a `StateFlow`
3. `data class Scroll(val currentQuery: String) : UiAction()` can be non null