### PR TITLE
fix: BUG #243 The incorrect splicing of the GitHub API results in emp…

### DIFF
--- a/advanced/end/app/src/main/java/com/example/android/codelabs/paging/api/GithubService.kt
+++ b/advanced/end/app/src/main/java/com/example/android/codelabs/paging/api/GithubService.kt
@@ -24,7 +24,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-const val IN_QUALIFIER = "in:name,description"
+const val IN_QUALIFIER = "+in:name,description"
 
 /**
  * Github API communication setup via Retrofit.

--- a/advanced/start/app/src/main/java/com/example/android/codelabs/paging/api/GithubService.kt
+++ b/advanced/start/app/src/main/java/com/example/android/codelabs/paging/api/GithubService.kt
@@ -24,7 +24,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-const val IN_QUALIFIER = "in:name,description"
+const val IN_QUALIFIER = "+in:name,description"
 
 /**
  * Github API communication setup via Retrofit.


### PR DESCRIPTION
…ty data from the request.

before：

![image](https://github.com/android/codelab-android-paging/assets/18367427/6a6e29be-26e4-456b-b79e-673d86649653)


after：

![image](https://github.com/android/codelab-android-paging/assets/18367427/9fde5c5c-08f8-46ec-bdce-c85fd7affa7d)
